### PR TITLE
Fix #2 Adjust Generated SQL in Error Log

### DIFF
--- a/YOUR_ADMIN/includes/init_includes/init_zca_responsive_classic_admin.php
+++ b/YOUR_ADMIN/includes/init_includes/init_zca_responsive_classic_admin.php
@@ -15,7 +15,7 @@ if (zen_is_superuser()) {
     // So far, no additional values have been inserted.
     //
     $zca_responsive_classic_config_changes = array();
-    
+
     // -----
     // 1) Configuration->Layout Settings:
     //
@@ -55,7 +55,7 @@ if (zen_is_superuser()) {
              VALUES
                 ('Responsive Mobile Full Site Version Width', 'SET_MAX_WIDTH', '1024', 'Set Width of Responsive Mobile Full Site Version<br />Default is <b>1024px</b>, To give mobile users same experience.', 19, NOW(), 203, NULL , NULL)"
         );
-    }  
+    }
     // -----
     // 2) Configuration->Product Listing
     //
@@ -96,8 +96,8 @@ if (zen_is_superuser()) {
              VALUES
                 ('Listing Columns Per Row (Mobile)', 'PRODUCT_LISTING_COLUMNS_PER_ROW_MOBILE', '1', '<br /><br />Set the number of columns (products) to show in each row on product listing pages for mobile devices. The default setting is 1.', 8, NOW(), 203, NULL , NULL)"
         );
-    }				
-    
+    }
+
     // -----
     // 3) Configuration->Product Info
     //
@@ -110,7 +110,7 @@ if (zen_is_superuser()) {
              VALUES
                 ('Use Photoswipe Lightbox', 'ZCA_PHOTOSWIPE_STATUS', 'false', 'Default is <b>false</b>, Opens images in an individual modal, <b>true</b> opens images in a photoswipe lightbox.', 18, NOW(), 200, NULL, 'zen_cfg_select_option(array(''true'',''false''),')"
         );
-    }			
+    }
     if (!defined('SHOW_PRODUCT_INFO_COLUMNS_ALSO_PURCHASED_PRODUCTS_TABLET')) {
         $zca_responsive_classic_config_changes[] = $zca_which_group . 'Also Purchased Products Columns per Row (Tablet)';
         $db->Execute(
@@ -119,7 +119,7 @@ if (zen_is_superuser()) {
              VALUES
                 ('Also Purchased Products Columns per Row (Tablet)', 'SHOW_PRODUCT_INFO_COLUMNS_ALSO_PURCHASED_PRODUCTS_TABLET', '2', 'Also Purchased Products Columns per row on (Tablet Devices). Default = 2', 18, NOW(), 202, NULL, 'zen_cfg_select_option(array(\'0\', \'1\', \'2\', \'3\', \'4\', \'5\', \'6\', \'7\', \'8\', \'9\', \'10\', \'11\', \'12\'),')"
         );
-    }	
+    }
     if (!defined('SHOW_PRODUCT_INFO_COLUMNS_ALSO_PURCHASED_PRODUCTS_MOBILE')) {
         $zca_responsive_classic_config_changes[] = $zca_which_group . 'Also Purchased Products Columns per Row (Mobile)';
         $db->Execute(
@@ -128,7 +128,7 @@ if (zen_is_superuser()) {
              VALUES
                 ('Also Purchased Products Columns per Row (Mobile)', 'SHOW_PRODUCT_INFO_COLUMNS_ALSO_PURCHASED_PRODUCTS_MOBILE', '1', 'Also Purchased Products Columns per row on (Mobile Devices). Default = 1', 18, NOW(), 203, NULL, 'zen_cfg_select_option(array(\'0\', \'1\', \'2\', \'3\', \'4\', \'5\', \'6\', \'7\', \'8\', \'9\', \'10\', \'11\', \'12\'),')"
         );
-    }				
+    }
     // -----
     // 3) Configuration->Images
     //
@@ -141,7 +141,7 @@ if (zen_is_superuser()) {
              VALUES
                 ('Product Info - Number of Additional Images per Row (Mobile)', 'IMAGES_AUTO_ADDED_MOBILE', '1', 'Product Info - Enter the number of additional images to display per row on (Mobile Devices). Default = 1', 4, NOW(), 200, NULL, 'zen_cfg_select_option(array(\'0\', \'1\', \'2\', \'3\', \'4\', \'5\', \'6\', \'7\', \'8\', \'9\', \'10\', \'11\', \'12\'),')"
         );
-    }			
+    }
     if (!defined('IMAGES_AUTO_ADDED_TABLET')) {
         $zca_responsive_classic_config_changes[] = $zca_which_group . 'Product Info - Number of Additional Images per Row (Tablet)';
         $db->Execute(
@@ -150,7 +150,7 @@ if (zen_is_superuser()) {
              VALUES
                 ('Product Info - Number of Additional Images per Row (Tablet)', 'IMAGES_AUTO_ADDED_TABLET', '2', 'Enter the number of additional images to display per row on (Tablet Devices). Default = 2', 4, NOW(), 201, NULL, 'zen_cfg_select_option(array(\'0\', \'1\', \'2\', \'3\', \'4\', \'5\', \'6\', \'7\', \'8\', \'9\', \'10\', \'11\', \'12\'),')"
         );
-    }	
+    }
     // -----
     // 3) Configuration->Maximum Values
     //
@@ -163,7 +163,7 @@ if (zen_is_superuser()) {
              VALUES
                 ('Categories To List Per Row (Mobile)', 'MAX_DISPLAY_CATEGORIES_PER_ROW_MOBILE', '1', 'How many categories to list per row on (Mobile Devices). Default = 1', 3, NOW(), 200, NULL, 'zen_cfg_select_option(array(\'0\', \'1\', \'2\', \'3\', \'4\', \'5\', \'6\', \'7\', \'8\', \'9\', \'10\', \'11\', \'12\'),')"
         );
-    }			
+    }
     if (!defined('MAX_DISPLAY_CATEGORIES_PER_ROW_TABLET')) {
         $zca_responsive_classic_config_changes[] = $zca_which_group . 'Categories To List Per Row (Tablet)';
         $db->Execute(
@@ -172,7 +172,7 @@ if (zen_is_superuser()) {
              VALUES
                 ('Categories To List Per Row (Tablet)', 'MAX_DISPLAY_CATEGORIES_PER_ROW_TABLET', '2', 'How many categories to list per row on (Tablet Devices). Default = 2', 3, NOW(), 201, NULL, 'zen_cfg_select_option(array(\'0\', \'1\', \'2\', \'3\', \'4\', \'5\', \'6\', \'7\', \'8\', \'9\', \'10\', \'11\', \'12\'),')"
         );
-    }	
+    }
     // -----
     // 3) Configuration->Index Listing
     //
@@ -185,7 +185,7 @@ if (zen_is_superuser()) {
              VALUES
                 ('Featured Products Columns per Row (Mobile)', 'SHOW_PRODUCT_INFO_COLUMNS_FEATURED_PRODUCTS_MOBILE', '1', 'Featured Products Columns per row on (Mobile Devices). Default = 1', 24, NOW(), 200, NULL, 'zen_cfg_select_option(array(\'0\', \'1\', \'2\', \'3\', \'4\', \'5\', \'6\', \'7\', \'8\', \'9\', \'10\', \'11\', \'12\'),')"
         );
-    }			
+    }
     if (!defined('SHOW_PRODUCT_INFO_COLUMNS_FEATURED_PRODUCTS_TABLET')) {
         $zca_responsive_classic_config_changes[] = $zca_which_group . 'Featured Products Columns per Row (Tablet)';
         $db->Execute(
@@ -203,7 +203,7 @@ if (zen_is_superuser()) {
              VALUES
                 ('New Products Columns per Row (Mobile)', 'SHOW_PRODUCT_INFO_COLUMNS_NEW_PRODUCTS_MOBILE', '1', 'New Products Columns per row on (Mobile Devices). Default = 1', 24, NOW(), 200, NULL, 'zen_cfg_select_option(array(\'0\', \'1\', \'2\', \'3\', \'4\', \'5\', \'6\', \'7\', \'8\', \'9\', \'10\', \'11\', \'12\'),')"
         );
-    }			
+    }
     if (!defined('SHOW_PRODUCT_INFO_COLUMNS_NEW_PRODUCTS_TABLET')) {
         $zca_responsive_classic_config_changes[] = $zca_which_group . 'New Products Columns per Row (Tablet)';
         $db->Execute(
@@ -221,7 +221,7 @@ if (zen_is_superuser()) {
              VALUES
                 ('Special Products Columns per Row (Mobile)', 'SHOW_PRODUCT_INFO_COLUMNS_SPECIALS_PRODUCTS_MOBILE', '1', 'Special Products Columns per row on (Mobile Devices). Default = 1', 24, NOW(), 200, NULL, 'zen_cfg_select_option(array(\'0\', \'1\', \'2\', \'3\', \'4\', \'5\', \'6\', \'7\', \'8\', \'9\', \'10\', \'11\', \'12\'),')"
         );
-    }			
+    }
     if (!defined('SHOW_PRODUCT_INFO_COLUMNS_SPECIALS_PRODUCTS_TABLET')) {
         $zca_responsive_classic_config_changes[] = $zca_which_group . 'Special Products Columns per Row (Tablet)';
         $db->Execute(
@@ -230,7 +230,7 @@ if (zen_is_superuser()) {
              VALUES
                 ('Special Products Columns per Row (Tablet)', 'SHOW_PRODUCT_INFO_COLUMNS_SPECIALS_PRODUCTS_TABLET', '2', 'Special Products Columns per row on (Tablet Devices). Default = 2', 24, NOW(), 201, NULL, 'zen_cfg_select_option(array(\'0\', \'1\', \'2\', \'3\', \'4\', \'5\', \'6\', \'7\', \'8\', \'9\', \'10\', \'11\', \'12\'),')"
         );
-    }						
+    }
     // -----
     // If any insertions were performed above, let the admin know via message.
     //
@@ -238,7 +238,7 @@ if (zen_is_superuser()) {
         $zca_responsive_classic_config_changes = '<ol><li>' . implode('</li><li>', $zca_responsive_classic_config_changes) . '</li></ol>';
         $messageStack->add(sprintf(ZCA_DIY_SETTINGS_ADDED, $zca_responsive_classic_config_changes), 'warning');
     }
-    
+
     // -----
     // Next, update the description and title of a couple of the built-in settings to let the store owner know that
     // they're not applicable/used when the ZCA DIY templates is active.
@@ -316,16 +316,16 @@ if (zen_is_superuser()) {
 
 //		$db->Execute(
 //		"ALTER TABLE " . TABLE_LAYOUT_BOXES . " DROP COLUMN layout_box_status_mobile");
-		
+
 //		$db->Execute(
-//		"ALTER TABLE " . TABLE_LAYOUT_BOXES . " DROP COLUMN layout_box_status_tablet");		
-		
+//		"ALTER TABLE " . TABLE_LAYOUT_BOXES . " DROP COLUMN layout_box_status_tablet");
+
 //		$db->Execute(
 //		"ALTER TABLE " . TABLE_LAYOUT_BOXES . " ADD COLUMN layout_box_status_mobile TINYINT(1) NOT NULL default '1' after layout_box_status_single");
-		
+
 //		$db->Execute(
 //		"ALTER TABLE " . TABLE_LAYOUT_BOXES . " ADD COLUMN layout_box_status_tablet TINYINT(1) NOT NULL default '1' after layout_box_status_mobile");
-		
+
 // -----
 // If the current template has just been CHANGED to the ZCA Responsive Classic (or a clone), ensure that the
 // Zen Cart configuration values required contain the recommended values for the template (if existing).
@@ -348,16 +348,17 @@ if ($current_page == (FILENAME_TEMPLATE_SELECT . '.php') && isset($_GET['action'
             'PRODUCT_LISTING_MULTIPLE_ADD_TO_CART' => '0'
         );
         $sql_update = '';
+        $zca_table_configuration = preg_replace("/".DB_PREFIX."/", '', TABLE_CONFIGURATION, 1);
         foreach ($zca_responsive_classic_configs as $key => $value) {
             if (constant($key) != $value) {
-                $sql_update .= ("UPDATE " . TABLE_CONFIGURATION . " SET configuration_value = '$value', last_modified = now() WHERE configuration_key = '$key' LIMIT 1;" . PHP_EOL);
+                $sql_update .= ("UPDATE " . $zca_table_configuration . " SET configuration_value = '$value', last_modified = now() WHERE configuration_key = '$key' LIMIT 1;" . PHP_EOL);
             }
         }
-        
+
         if ($sql_update != '') {
             $logfile_name = DIR_FS_LOGS . '/zca_responsive_classic_' . date('YmdHis') . '.log';
             $messageStack->add(sprintf(ZCA_DIY_CONFIG_WARNING, $logfile_name), 'warning');
-            
+
             $logfile_data = 'The ZCA "Responsive Classic" template (or a clone) was activated on ' . date('Y-m-d H:i:s') . ' and some of its default settings are different than those currently set.  You can copy and paste the following SQL into your admin\'s Tools->Install SQL Patches to change those defaults:' . PHP_EOL . PHP_EOL . $sql_update;
             error_log($logfile_data, 3, $logfile_name);
         }


### PR DESCRIPTION
Remove the prefix from table names in the SQL commands saved to the log
file for users to apply as a patch.

Patches entered through the admin tools pass through the query factory
which prepends the prefix to table names. Pasting the output of from
the log file into that interface results in the table names having a
double prefix, and therefore not being valid table names.

Resolves zcadditions/ZCA-Responsive-Classic-for-Zen-Cart-1.5.6-v1.0.0#2

Signed-off-by: Ronald Lamoreaux <gitkey@chindraba.work>